### PR TITLE
Add hosts enum

### DIFF
--- a/src/shared/hosts.spec.ts
+++ b/src/shared/hosts.spec.ts
@@ -1,0 +1,52 @@
+/// <reference types="@rbxts/testez/globals" />
+import { Host } from "./hosts";
+
+export = (): void => {
+	describe("None", () => {
+		it("should exist", () => {
+			expect(Host.None).to.be.ok();
+		});
+
+		it("should be unique", () => {
+			expect(Host.None).never.to.equal(Host.Client);
+			expect(Host.None).never.to.equal(Host.Server);
+			expect(Host.None).never.to.equal(Host.All);
+		});
+	});
+
+	describe("Client", () => {
+		it("should exist", () => {
+			expect(Host.Client).to.be.ok();
+		});
+
+		it("should be unique", () => {
+			expect(Host.Client).never.to.equal(Host.None);
+			expect(Host.Client).never.to.equal(Host.Server);
+			expect(Host.Client).never.to.equal(Host.All);
+		});
+	});
+
+	describe("Server", () => {
+		it("should exist", () => {
+			expect(Host.Server).to.be.ok();
+		});
+
+		it("should be unique", () => {
+			expect(Host.Server).never.to.equal(Host.None);
+			expect(Host.Server).never.to.equal(Host.Client);
+			expect(Host.Server).never.to.equal(Host.All);
+		});
+	});
+
+	describe("All", () => {
+		it("should exist", () => {
+			expect(Host.All).to.be.ok();
+		});
+
+		it("should be unique", () => {
+			expect(Host.All).never.to.equal(Host.None);
+			expect(Host.All).never.to.equal(Host.Client);
+			expect(Host.All).never.to.equal(Host.Server);
+		});
+	});
+};

--- a/src/shared/hosts.ts
+++ b/src/shared/hosts.ts
@@ -1,0 +1,6 @@
+export enum Host {
+	None,
+	Client,
+	Server,
+	All,
+}


### PR DESCRIPTION
## Proposed changes

This adds a host enum for determining host mode throughout the project. This allows avoiding the common pitfall of relying on the RunService for this information in disparate areas of the code.