### PR TITLE
Add systems loader

### DIFF
--- a/src/server/systems/test.ts
+++ b/src/server/systems/test.ts
@@ -1,0 +1,5 @@
+function test(): void {
+	// A test system.
+}
+
+export = test;

--- a/src/shared/systems.spec.ts
+++ b/src/shared/systems.spec.ts
@@ -1,0 +1,82 @@
+/// <reference types="@rbxts/testez/globals" />
+import { AnySystem, Debugger, Loop } from "@rbxts/matter";
+import Plasma from "@rbxts/plasma";
+import { Host } from "shared/hosts";
+import { start, stop } from "./systems";
+
+interface MockLoop extends Loop<unknown[]> {
+	systems: AnySystem[];
+}
+
+function mockLoop(): MockLoop {
+	const loop = new Loop() as unknown as MockLoop;
+	loop.systems = [];
+
+	loop.scheduleSystems = (<S extends Array<AnySystem>>(_: never, systems: S): void => {
+		loop.systems = systems;
+	}) as <S extends Array<AnySystem>>(systems: S) => void;
+
+	return loop;
+}
+
+export = (): void => {
+	const debug = new Debugger(Plasma);
+	let loop: MockLoop;
+
+	describe("start", () => {
+		beforeEach(() => {
+			loop = mockLoop();
+		});
+
+		afterEach(() => {
+			stop();
+		});
+
+		it("should not throw for None", () => {
+			expect(() => start(Host.None, loop, debug)).never.to.throw();
+		});
+
+		it("should not throw for Client", () => {
+			expect(() => start(Host.Client, loop, debug)).never.to.throw();
+		});
+
+		it("should not throw for Server", () => {
+			expect(() => start(Host.Server, loop, debug)).never.to.throw();
+		});
+
+		it("should not throw for All", () => {
+			expect(() => start(Host.All, loop, debug)).never.to.throw();
+		});
+
+		it("should schedule systems for None", () => {
+			start(Host.None, loop, debug);
+			expect(loop.systems.isEmpty()).to.equal(false);
+		});
+
+		it("should schedule systems for Client", () => {
+			start(Host.Client, loop, debug);
+			expect(loop.systems.isEmpty()).to.equal(false);
+		});
+
+		it("should schedule systems for Server", () => {
+			start(Host.Server, loop, debug);
+			expect(loop.systems.isEmpty()).to.equal(false);
+		});
+
+		it("should schedule systems for All", () => {
+			start(Host.All, loop, debug);
+			expect(loop.systems.isEmpty()).to.equal(false);
+		});
+	});
+
+	describe("stop", () => {
+		beforeEach(() => {
+			loop = mockLoop();
+			start(Host.All, loop, debug);
+		});
+
+		it("should not throw", () => {
+			expect(() => stop()).never.to.throw();
+		});
+	});
+};

--- a/src/shared/systems/client/test.ts
+++ b/src/shared/systems/client/test.ts
@@ -1,0 +1,5 @@
+function test(): void {
+	// A test system.
+}
+
+export = test;

--- a/src/shared/systems/index.ts
+++ b/src/shared/systems/index.ts
@@ -1,0 +1,83 @@
+import { ServerScriptService } from "@rbxts/services";
+import { AnySystem, Debugger, Loop } from "@rbxts/matter";
+import { Context, HotReloader } from "@rbxts/rewire";
+import { Host } from "shared/hosts";
+
+const ERROR_CONTAINER = "%s container not found";
+
+const shared = script.FindFirstChild("shared");
+const client = script.FindFirstChild("client");
+const server = ServerScriptService.FindFirstChild("sentinel")?.FindFirstChild("systems");
+
+let firstRunSystems: AnySystem[] | undefined = [];
+let hotReloader: HotReloader | undefined;
+
+export function start<T extends unknown[]>(container: Host, loop: Loop<T>, debug: Debugger): void {
+	if (!firstRunSystems) return;
+
+	const containers: Instance[] = [];
+	if (!shared) throw string.format(ERROR_CONTAINER, "Shared");
+	containers.push(shared);
+
+	if (container === Host.All || container === Host.Client) {
+		if (!client) throw string.format(ERROR_CONTAINER, "Client");
+		containers.push(client);
+	}
+	if (container === Host.All || container === Host.Server) {
+		if (!server) throw string.format(ERROR_CONTAINER, "Server");
+		containers.push(server);
+	}
+
+	const systemsByModule: Map<ModuleScript, AnySystem> = new Map();
+
+	function load(module: ModuleScript, context: Context): void {
+		const original = context.originalModule;
+		const previous = systemsByModule.get(original);
+		const [ok, required] = pcall(require, module);
+
+		if (!ok) {
+			warn("Error when hot-reloading system", module.Name, required);
+			return;
+		}
+
+		// Here we don't know that this is necessarily a system, but we let matter
+		// handle this at runtime.
+		const system = required as AnySystem;
+
+		if (firstRunSystems) {
+			firstRunSystems.push(system);
+		} else if (previous) {
+			loop.replaceSystem(previous, system);
+			debug.replaceSystem(previous, system);
+		} else {
+			loop.scheduleSystem(system);
+		}
+
+		systemsByModule.set(original, system);
+	}
+
+	function unload(_: ModuleScript, context: Context): void {
+		if (context.isReloading) return;
+
+		const original = context.originalModule;
+		const previous = systemsByModule.get(original);
+		if (previous) {
+			loop.evictSystem(previous);
+			systemsByModule.delete(original);
+		}
+	}
+
+	hotReloader = new HotReloader();
+	for (const container of containers) {
+		hotReloader.scan(container, load, unload);
+	}
+
+	loop.scheduleSystems(firstRunSystems);
+	firstRunSystems = undefined;
+}
+
+export function stop(): void {
+	if (firstRunSystems) return;
+	firstRunSystems = [];
+	hotReloader?.destroy();
+}

--- a/src/shared/systems/shared/test.ts
+++ b/src/shared/systems/shared/test.ts
@@ -1,0 +1,5 @@
+function test(): void {
+	// A test system.
+}
+
+export = test;


### PR DESCRIPTION
## Proposed changes

Adds a systems loader to load all systems from containers appropriate to the host. Additionally includes several test systems in each container.

## Additional comments

Unfortunately there is not much to do in the way of testing for this loader, since the primary operation this loader handles is based on the configuration/updating of the project files to facilitate hot loading.