### PR TITLE
Fix matter debugger cleanup

### DIFF
--- a/src/shared/ecs/index.ts
+++ b/src/shared/ecs/index.ts
@@ -85,4 +85,5 @@ export function stop(): void {
 	stopTags();
 	stopReplication();
 	stopSystems();
+	ReplicatedStorage.FindFirstChild("MatterDebuggerRemote")?.Destroy();
 }

--- a/src/shared/systems.spec.ts
+++ b/src/shared/systems.spec.ts
@@ -1,4 +1,5 @@
 /// <reference types="@rbxts/testez/globals" />
+import { ReplicatedStorage } from "@rbxts/services";
 import { AnySystem, Debugger, Loop } from "@rbxts/matter";
 import Plasma from "@rbxts/plasma";
 import { Host } from "shared/hosts";
@@ -20,8 +21,16 @@ function mockLoop(): MockLoop {
 }
 
 export = (): void => {
-	const debug = new Debugger(Plasma);
+	let debug: Debugger;
 	let loop: MockLoop;
+
+	beforeAll(() => {
+		debug = new Debugger(Plasma);
+	});
+
+	afterAll(() => {
+		ReplicatedStorage.FindFirstChild("MatterDebuggerRemote")?.Destroy();
+	});
 
 	describe("start", () => {
 		beforeEach(() => {


### PR DESCRIPTION
## Proposed changes

Previously, we fail to clean up after the matter debugger properly. This cleans up the remote event it creates.
