### PR TITLE
Update component archetypes name to types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
   - The server uses `serverEntityId`
   - The client uses `clientEntityId`
   - Otherwise `unknownEntityId` is used
-- A component system along with component archetypes
+- A component system along with component types
 - Spawning for tagged components based on a set of tags bound to their
   associated components
 - The ECS global state

--- a/src/shared/components/defaults.ts
+++ b/src/shared/components/defaults.ts
@@ -1,4 +1,4 @@
-import { Transform } from "./archetypes";
+import { Transform } from "./types";
 
 /**
  * The default value created when no data is provided to a {@link Transform}

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,16 +1,16 @@
 import { component } from "@rbxts/matter";
-import { Model as ModelArchetype, Transform as TransformArchetype } from "./archetypes";
+import { Model as ModelComponent, Transform as TransformComponent } from "./types";
 import { transform } from "./defaults";
 
 /**
- * The {@link ModelArchetype | Model} component constructor.
+ * The {@link ModelComponent | Model} component constructor.
  */
-export const Model = component<ModelArchetype>("Model");
+export const Model = component<ModelComponent>("Model");
 
 /**
- * The {@link TransformArchetype | Transform} component constructor.
+ * The {@link TransformComponent | Transform} component constructor.
  */
-export const Transform = component<TransformArchetype>("Transform", transform);
+export const Transform = component<TransformComponent>("Transform", transform);
 
 /**
  * This is a test component constructor.

--- a/src/shared/components/types.d.ts
+++ b/src/shared/components/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * The Model component archetype.
+ * The Model component.
  *
  * Provides a reference to the {@link PVInstance} that represents the attached
  * entity.
@@ -9,7 +9,7 @@ export interface Model {
 }
 
 /**
- * The Transform component archetype.
+ * The Transform component.
  *
  * Provides a reference {@link CFrame} that represents the world transform of
  * the attached entity.

--- a/src/shared/ecs/replication.ts
+++ b/src/shared/ecs/replication.ts
@@ -6,7 +6,7 @@ import { State } from "./state";
 type ComponentNames = keyof typeof Components;
 type ComponentConstructors = (typeof Components)[ComponentNames];
 type Components = ReturnType<ComponentConstructors>;
-type Archetypes = Parameters<ComponentConstructors>[0];
+type ComponentTypes = Parameters<ComponentConstructors>[0];
 
 const DEBUG_SPAWN = "Spawn %ds%d with %s";
 const DEBUG_DESPAWN = "Despawn %ds%d";
@@ -33,7 +33,7 @@ export function start(world: World, state: State): void {
 	const serverToClientEntity = new Map<string, AnyEntity>();
 
 	connection = replicationEvent.OnClientEvent.Connect(
-		(entities: Map<string, Map<ComponentNames, { data?: Archetypes }>>) => {
+		(entities: Map<string, Map<ComponentNames, { data?: ComponentTypes }>>) => {
 			for (const [serverId, componentMap] of entities) {
 				const clientId = serverToClientEntity.get(serverId);
 
@@ -62,7 +62,7 @@ export function start(world: World, state: State): void {
 							// it was created with, but the type checker can't verify this for
 							// us. To solve this the type must somehow be associated with the
 							// name in the type system. For now, this cast works fine.
-							component(container.data as UnionToIntersection<Archetypes>),
+							component(container.data as UnionToIntersection<ComponentTypes>),
 						);
 						insertNames.push(name);
 					} else {

--- a/src/shared/ecs/tags.spec.ts
+++ b/src/shared/ecs/tags.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="@rbxts/testez/globals" />
 import { CollectionService } from "@rbxts/services";
 import { component } from "@rbxts/matter";
-import { Transform, Model } from "shared/components/archetypes";
+import { Transform, Model } from "shared/components/types";
 import { MockWorld, mockWorld } from "./mockWorld.dev";
 import { ComponentConstructor, start, stop } from "./tags";
 


### PR DESCRIPTION
## Proposed changes

The name archetypes is confusing with matter's archetypes. While the name "types" isn't particularly useful, this helps clear that confusion.
