### PR TITLE
Remove unnecessary test systems

### DIFF
--- a/src/server/systems/server/test.ts
+++ b/src/server/systems/server/test.ts
@@ -1,8 +1,0 @@
-/**
- * A test system that does nothing.
- */
-function test(): void {
-	// A test system.
-}
-
-export = test;

--- a/src/server/systems/server/updateTransforms.spec.ts
+++ b/src/server/systems/server/updateTransforms.spec.ts
@@ -6,8 +6,6 @@ import removeMissingModels from "./removeMissingModels";
 import updateTransforms from "./updateTransforms";
 
 export = (): void => {
-	FOCUS();
-
 	describe("system", () => {
 		const event = new Instance("BindableEvent");
 		let instance: Model;

--- a/src/shared/systems/shared/test.ts
+++ b/src/shared/systems/shared/test.ts
@@ -1,8 +1,0 @@
-/**
- * A test system that does nothing.
- */
-function test(): void {
-	// A test system.
-}
-
-export = test;


### PR DESCRIPTION
## Proposed changes

This removes the shared and server test systems as they're no longer necessary (previously they existed to facilitate the testing of systems code that required systems to be loaded). One additional test systems remains on the client that must be removed later as well.