### PR TITLE
Add blog page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 	<a href="https://github.com/LastTalon/sentinel/actions/workflows/ci.yaml">
 		<img src="https://github.com/LastTalon/sentinel/actions/workflows/ci.yaml/badge.svg" alt="CI Status">
 	</a>
+  <a href="https://discord.gg/aq2UkZUWsj">
+    <img src="https://img.shields.io/discord/763938195586416681?logo=discord&colorB=7289DA" alt="Discord">
+	</a>
 </div>
 <br>
 
@@ -13,7 +16,10 @@
 Sentinel is a cooperative, hero-based, wave-based horde survival game. More
 information to come.
 
+Where starting a [blog]. Check it out to check in on development.
+
 [roblox]: https://www.roblox.com/
+[blog]: blog/intro.md
 
 ## Building
 

--- a/blog/intro.md
+++ b/blog/intro.md
@@ -1,0 +1,107 @@
+# Broadcast Intercepted: Development Live Streams
+
+Hello there, friend.
+
+If you've been following along with my project, _Sentinel_, you might be
+interested to hear that I've decided to take things in a new direction. Starting
+soon, I'll be live streaming my development process on [Twitch]. This is a
+journey I've been eager to embark on, and I'm genuinely thrilled to share it
+with you. In this post, I'll let you in on what you can expect from these live
+streams and why I believe this journey can be an enriching adventure for
+everyone.
+
+I am excited to reveal that starting from tomorrow, Tuesday, June 13th, I'll be
+opening the doors of my development process, and you're invited to join me.
+You'll get a front-row seat as I code, make design decisions, and tackle the
+very real challenges that come with software development.
+
+To skip to the stream invitation, [check below](#youre-invited).
+
+## Description of Streaming Content
+
+These live streams provide a peek inside the code editor of a developer. They're
+a shared journey, a platform to explore the multifaceted process of creating
+_Sentinel_, a project that's very close to my heart. A development live stream
+is an opportunity to watch a software project come to life in real-time. You'll
+get to see everything: the code being written, problems being debugged, and
+features being designed and implemented.
+
+For those unfamiliar with the project, _Sentinel_ is a cooperative, hero-based,
+horde survival game. It's designed for the _Roblox_ platform, targeting players
+aged 12 and above who seek a more mature, thrilling gaming experience. Drawing
+inspiration from popular games like _Dota_ and horde survival games like
+_Killing Floor_ or _Left 4 Dead_, _Sentinel_ is packed with exciting game modes,
+challenging boss battles, and a robust progression system. I genuinely believe
+it holds the potential to become a standout title on the _Roblox_ platform.
+
+But I want to give you more than just a front-row seat to coding. I want to
+share the full breadth of the development journey with you. True development
+goes beyond just writing software; it encompasses planning, iterating, refining,
+and sometimes, starting from scratch. From setting up documentation and this
+blog to managing our issue tracker, these streams will offer a holistic look
+into the development process. It's about laying bare the realities of creating
+something from scratch, warts and all, and I couldn't be more excited to share
+it with you.
+
+## Why Reveal My Secrets?
+
+Why have I decided to broadcast my journey? There are several reasons, but they
+all converge on a single value: openness. I am a strong believer in the
+[philosophy](http://www.catb.org/~esr/writings/cathedral-bazaar/) of "developing
+in the open." This principle extends beyond just making the source code publicly
+available. It encompasses sharing the thought processes, the struggles, the
+eureka moments, the disappointments, and the victories that come with the
+journey of software development. By exposing the entire lifecycle of a project,
+we foster a sense of authenticity, allowing for a richer learning and
+community-building experience.
+
+These live streams are an extension of this belief, serving as a live
+documentation of _Sentinel's_ development process. My hope is that these
+sessions provide a valuable educational resource, offering a first-hand look
+into the nitty-gritty of developing a software project. It's a platform for
+learning, but also an invitation to join the conversation, to share insights,
+and to learn together. This transparency isn't just about my growth as a
+developer, but also about helping each other grow, and learning from one
+another's experiences.
+
+And it's not just about learning. I believe that watching a project evolve,
+engaging in the process, and experiencing the triumphs and challenges along the
+way, also fosters a sense of camaraderie and community. I hope to make these
+streams not just informative, but also an enjoyable space where we can connect
+over shared passions and experiences.
+
+## End of Transmission
+
+Thank you all for your support and for sharing this journey with me. In these
+streams, you're not just a spectator, but an integral part of the development
+process. I look forward to learning, growing, and creating with you. Who knows
+where this adventure will lead us?
+
+## You're Invited
+
+I'd love for you to be a part of this journey with me. Here's how you can join
+in:
+
+Join me live on [Twitch] for some thrilling _Sentinel_ development sessions.
+Mark your calendars for these dates (all times in Central Time (CT), and
+Coordinated Universal Time (UTC)):
+
+- Tuesday, June 13, 2023: 8:30 PM CT / 1:30 AM UTC (next day)
+- Wednesday, June 14, 2023: 8:30 PM CT / 1:30 AM UTC (next day)
+- Thursday, June 15, 2023: 8:30 PM CT / 1:30 AM UTC (next day)
+- Friday, June 16, 2023: 8:30 PM CT / 1:30 AM UTC (next day)
+- Saturday, June 17, 2023: 8:30 PM CT / 1:30 AM UTC (next day)
+
+Each stream will run for approximately 2-3 hours.
+
+For an even more engaging experience, come join our [Discord] community. You'll
+find all the latest updates, get the chance to discuss the development process,
+and connect with fellow _Sentinel_ enthusiasts.
+
+And for more casual updates and interactions, you can find me on Twitter
+[@LastTalon](https://twitter.com/LastTalon) and Mastodon
+[@LastTalon@mastodon.gamedev.place](https://mastodon.gamedev.place/@LastTalon).
+Looking forward to connecting with you!
+
+[discord]: https://discord.gg/aq2UkZUWsj
+[twitch]: https://www.twitch.tv/lasttalon


### PR DESCRIPTION
## Proposed changes

This adds the first blog page for Sentinel, introducing live streams.
